### PR TITLE
Update Valid.pm

### DIFF
--- a/lib/Email/Valid.pm
+++ b/lib/Email/Valid.pm
@@ -73,7 +73,7 @@ sub _rearrange {
   my(%args);
 
   ref $self ? %args = %$self : _initialize( \%args );
-  return %args unless @params;
+  return %args unless exists $params[0];
 
   unless ($params[0] =~ /^-/ and @params > 1) {
     while(@params) {


### PR DESCRIPTION
In some case _rearrange breaks with an error about @params[0] uninitialized in line 78. Test @params instead of $params[0] is not enough.