### PR TITLE
Improved Net::DNS MX Record Checking

### DIFF
--- a/lib/Email/Valid.pm
+++ b/lib/Email/Valid.pm
@@ -150,8 +150,8 @@ sub _net_dns_query {
     foreach my $mx (@mx_entries) {
       my $mxhost = $mx->exchange;
       my $query = $Resolver->search($mx);
-      foreach my $arr ($query->answer) {
-        return 1 unless $arr->type ne 'A';
+      foreach my $a_rr ($query->answer) {
+        return 1 unless $a_rr->type ne 'A';
       }
     }
   }

--- a/lib/Email/Valid.pm
+++ b/lib/Email/Valid.pm
@@ -151,7 +151,7 @@ sub _net_dns_query {
       my $mxhost = $mx->exchange;
       my $query = $Resolver->search($mx);
       foreach my $arr ($query->answer) {
-        return 1 unless $arr-type ne 'A';
+        return 1 unless $arr->type ne 'A';
       }
     }
   }

--- a/lib/Email/Valid.pm
+++ b/lib/Email/Valid.pm
@@ -144,22 +144,18 @@ sub _net_dns_query {
 
   $Resolver = Net::DNS::Resolver->new unless defined $Resolver;
 
-  my $packet = $Resolver->send($host, 'MX') or croak $Resolver->errorstring;
-  if ($packet->header->ancount) {
-    my @mx_entries = grep { $_->type eq 'MX' } $packet->answer;
-    if(@mx_entries) {
-        my $mx = ($mx_entries[0])->exchange;
-        if ($mx eq '.' or $mx eq '') {
-          return $self->details('mx'); # Null MX
-        } else {
-          return 1;
-        }
+  my @mx_entries = Net::DNS::mx($Resolver,$host);
+  
+  if (@mx_entries) {
+    foreach my $mx (@mx_entries) {
+      my $mxhost = $mx->exchange;
+      my $query = $Resolver->search($mx);
+      foreach my $arr ($query->answer) {
+        return 1 unless $arr-type ne 'A';
+      }
     }
   }
-
-  $packet = $Resolver->send($host, 'A') or croak $Resolver->errorstring;
-  return 1 if $packet->header->ancount;
-
+ 
   return $self->details('mx');
 }
 


### PR DESCRIPTION
For some domains (specifically one of my own I was testing against), the mxcheck routine was returning a false positive (pass) when it should have failed te4h test (i.e. no MX records in the DNS).

This shortened routine appears to get around that issue.