### PR TITLE
Minor pod document fix

### DIFF
--- a/lib/Email/Valid.pm
+++ b/lib/Email/Valid.pm
@@ -689,6 +689,6 @@ bug fixes:
 
 =head1 SEE ALSO
 
-Mail::Address, Net::DNS, Net::Domain::TLD, perlfaq9
+L<Mail::Address>, L<Net::DNS>, L<Net::Domain::TLD>, L<perlfaq9|https://metacpan.org/pod/distribution/perlfaq/lib/perlfaq9.pod>
 
 =cut


### PR DESCRIPTION
Hi Ricardo, 

Please review the following change.

 - Made 'SEE ALSO' entries a clickable link in the pod document of Email::Valid.

Many Thanks.

Best Regards,
Mohammad S Anwar